### PR TITLE
Report completeness bug

### DIFF
--- a/core/webservice.py
+++ b/core/webservice.py
@@ -1,0 +1,101 @@
+import requests
+import logging
+from urllib.parse import urljoin
+from requests.auth import HTTPBasicAuth
+
+class WebService:
+    def __init__(self, auth_token, protocol_type, host_name, project_name):
+        self.auth_token = auth_token
+        self.auth = HTTPBasicAuth(self.auth_token, "")
+        self.sqa_headers = {"Authorization": "Basic " + auth_token}
+        self.base_url = f"{protocol_type}{host_name}"
+        self.project_name = project_name
+        self.health_check()
+    
+    
+    def health_check(self):
+        try:
+            logging.debug(f"Auth token being used is :: {self.auth_token}")
+            logging.debug(f"Bearer Token being passed is :: {str(self.sqa_headers)}")
+            response = requests.get(self.base_url)
+            response.raise_for_status()
+        except Exception as e:
+            logging.debug(f"Healthcheck failed: {e}")
+
+
+    def get_unresolved_issues(self, page=1):
+        ''''
+            This function get the issues with resolved arg equals to false.
+            Arguments:
+                - page: Default argument to get the first page of issues
+            Returns:
+                Request response
+        '''
+
+        api_path = f"/api/issues/search"
+        url_to_hit = urljoin(self.base_url, api_path)
+
+        api_parameters = {
+            "componentKeys": self.project_name,
+            "resolved": "false",
+            "p": page
+        }
+
+        response = requests.get(url=url_to_hit, auth=self.auth, params=api_parameters)
+
+        return response
+    
+
+    def get_all_unresolved_issues(self, total: int, page_size: int) -> list:
+        ''''
+            This function iterates over the total issues, using the page_size
+            argument to decrease his value. This will ensure all issues in the report.
+        '''
+
+        response_list = []
+        issues_total = total
+        page_counter = 1
+        status_code = 0
+        
+        while issues_total > 0:
+            try:
+                response = self.get_unresolved_issues(page=page_counter)
+                response.raise_for_status()
+
+                logging.info(f"URL that has we are hitting to fetch SonarQube reports are {response.url}")
+                response_list.append(response)
+                issues_total -= page_size
+                page_counter += 1
+
+            except requests.exceptions.HTTPError as e:
+                logging.debug(f"Failed to get all unresolved issues: {e}")
+                return list(), status_code
+
+        status_code = 200
+
+        return response_list, status_code
+
+
+    def get_total_issues(self, request_function):
+        '''
+            This function get the total issues from your SonarQube project.
+            This information will be used to feed a while loop to get all the issues
+
+            Argument:
+                - request_function: The function used to get the issues
+
+            Returns:
+                - total: The integer value for total issues
+                - ps: The default page size returned by api
+        '''
+        
+        try:
+            response = request_function()
+            response.raise_for_status()
+            response = response.json()
+
+            total, ps = response["total"], response["ps"]
+
+            return total, ps
+        except requests.exceptions.HTTPError as e:
+            logging.debug(f"Failed to get total issues: {e}")

--- a/reports/templating.py
+++ b/reports/templating.py
@@ -164,7 +164,7 @@ def issue_summary_overview(bug_list, vulnerability_list, code_smell_list, duplic
 def create_issues_report(file_path, host_name, auth_token, project_name, protocol):
     response = analyser.get_reported_issues_by_sonarqube(
         host_name, auth_token, project_name, protocol)
-    if (response == ""):
+    if not response:
         logging.info(
             "We are sorry, we're having trouble generating your report")
         print("We are sorry, we're having trouble generating your report")


### PR DESCRIPTION
## Pull Request Summary

The purpose of this PR is to  fix a bug that limit the total issues in the pdf report.

To fix this bug, I created a webservice object to handle the api requests. This object also gets the total issues and default page size returned by a request response and iterate over all available pages. This behavior will return a list instead of a single response.

Later in the analyser flow, this list will be iterated by method get_issues_by_type.

---


## Checklist

- [x] I’ve tested this locally
- [ ] I’ve added/updated documentation
- [ ] I’ve added tests where needed
- [x] I’ve followed the project's code style

---

## Notes (Optional)

The web service object can be used to handle all other future requests.
Closes #23 
